### PR TITLE
Prefer the jenkinsci/jenkins image

### DIFF
--- a/jenkins/jenkins-rexray-df-proxy.yml
+++ b/jenkins/jenkins-rexray-df-proxy.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   main:
-    image: jenkins:${TAG:-2.32.3-alpine}
+    image: jenkinsci/jenkins:${TAG:-2.32.3-alpine}
     ports:
       - "50000:50000"
     environment:

--- a/jenkins/jenkins-rexray-df-proxy.yml
+++ b/jenkins/jenkins-rexray-df-proxy.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   main:
-    image: jenkinsci/jenkins:${TAG:-2.32.3-alpine}
+    image: jenkinsci/jenkins:${TAG:-lts-alpine}
     ports:
       - "50000:50000"
     environment:


### PR DESCRIPTION
The docker official library image requires manual updates to get security fixes to users. So the project has been advocating more strongly for users to rely on the image we have more automation and control around.