### PR TITLE
Adding xForwardedProto to registry service.

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -61,18 +61,35 @@ docker swarm init \
 
 docker network create --driver overlay proxy
 
-docker stack deploy \
+DOMAIN=localhost docker stack deploy \
     -c ../proxy/docker-flow-proxy.yml \
     proxy
 ```
 
-### Deployment
+## registry-df-proxy-ssl.yml
+
+This stack sets up Docker private registry integrated with *Docker Flow Proxy*.
+It also assumes that ssl is terminated at the proxy.
+
+### Requirements
+
+* Network called `proxy` is created
+* Docker Flow Proxy is running and has the environment variable `CONNECTION_MODE=http-keep-alive`
+* SSL Terminated at proxy.
 
 ```bash
-DOMAIN=localhost \
-    docker stack deploy \
-    -c registry-df-proxy.yml \
-    registry
+docker-machine create -d virtualbox test
+
+eval $(docker-machine env test)
+
+docker swarm init \
+    --advertise-addr $(docker-machine ip test)
+
+docker network create --driver overlay proxy
+
+DOMAIN=localhost docker stack deploy \
+    -c ../proxy/docker-flow-proxy-ssl.yml \
+    proxy
 ```
 
 ### Test

--- a/docker/registry-df-proxy-ssl.yml
+++ b/docker/registry-df-proxy-ssl.yml
@@ -1,0 +1,24 @@
+version: '3'
+
+services:
+
+  main:
+    image: registry
+    ports:
+      - "5000:5000"
+    networks:
+      - proxy
+    deploy:
+      resources:
+        reservations:
+          memory: 100M
+      labels:
+        - com.df.notify=true
+        - com.df.distribute=true
+        - com.df.port=5000
+        - com.df.serviceDomain=${DOMAIN}
+        - com.df.xForwardedProto=true
+
+networks:
+  proxy:
+    external: true


### PR DESCRIPTION
Without this configuration, the registry with interrupt
uoloads with 'unknown blob' error.