### PR TITLE
Fix comments for plugins on Jenkins Dockerfiles

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -6,7 +6,9 @@ ENV JAVA_OPTS="-Djenkins.install.runSetupWizard=false"
 # Creates username and password specified through environment variables JENKINS_USER_SECRET and JENKINS_PASS_SECRET
 COPY security.groovy /usr/share/jenkins/ref/init.groovy.d/security.groovy
 
-# Creates username and password specified through environment variables JENKINS_USER_SECRET and JENKINS_PASS_SECRET
-COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
+# Install groovy global libraries for pipeline plugin
 COPY var/jenkins_home/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml /usr/share/jenkins/ref/org.jenkinsci.plugins.workflow.libs.GlobalLibraries.xml
+
+# Install a list of plugins from the file 'plugins.txt' and their dependencies
+COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt

--- a/jenkins/Dockerfile.plugins
+++ b/jenkins/Dockerfile.plugins
@@ -6,6 +6,6 @@ ENV JAVA_OPTS="-Djenkins.install.runSetupWizard=false"
 # Creates username and password specified through environment variables JENKINS_USER_SECRET and JENKINS_PASS_SECRET
 COPY security.groovy /usr/share/jenkins/ref/init.groovy.d/security.groovy
 
-# Creates username and password specified through environment variables JENKINS_USER_SECRET and JENKINS_PASS_SECRET
+# Install a list of plugins from the file 'plugins.txt' and their dependencies
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt


### PR DESCRIPTION
The second comment on jenkins/Dockerfile was duplicated and had no reference on what is doing (install plugins). Changed the text to "Install a list of plugins from the file 'plugins.txt' and their dependencies". 

Also change the order of the files copied so the install plugins comment make sense on what is below.