### PR TITLE
Remove password from prying eyes

### DIFF
--- a/jenkins/jenkins-swarm-agent-secrets.yml
+++ b/jenkins/jenkins-swarm-agent-secrets.yml
@@ -13,7 +13,8 @@ services:
       - /workspace:/workspace
     secrets:
       - jenkins-user
-      - jenkins-pass
+      - source: jenkins-pass
+        mode: 0400
     deploy:
       mode: global
 

--- a/jenkins/jenkins-swarm-agent.yml
+++ b/jenkins/jenkins-swarm-agent.yml
@@ -5,7 +5,8 @@ services:
   main:
     image: vfarcic/jenkins-swarm-agent
     environment:
-      - COMMAND_OPTIONS=-master http://${JENKINS_IP}/jenkins -username ${MASTER_USER:-admin} -password ${MASTER_PASS:-admin} -labels 'docker' -executors 5
+      - COMMAND_OPTIONS=-master http://${JENKINS_IP}/jenkins -username ${MASTER_USER:-admin} -passwordEnvVariable PASSWORD_ENVVAR -labels 'docker' -executors 5
+      - PASSWORD_ENVVAR=${MASTER_PASS:-admin}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /workspace:/workspace

--- a/jenkins/jenkins-swarm-prod-agent-secrets.yml
+++ b/jenkins/jenkins-swarm-prod-agent-secrets.yml
@@ -13,7 +13,8 @@ services:
       - /workspace:/workspace
     secrets:
       - jenkins-user
-      - jenkins-pass
+      - source: jenkins-pass
+        mode: 0400
     deploy:
       mode: global
       placement:

--- a/jenkins/vfarcic-jenkins-agent.yml
+++ b/jenkins/vfarcic-jenkins-agent.yml
@@ -12,7 +12,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     secrets:
       - jenkins-user
-      - jenkins-pass
+      - source: jenkins-pass
+        mode: 0400
     deploy:
       placement:
         constraints: [node.role == manager]

--- a/jenkins/vfarcic-jenkins-df-proxy-aws-full.yml
+++ b/jenkins/vfarcic-jenkins-df-proxy-aws-full.yml
@@ -41,7 +41,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     secrets:
       - jenkins-user
-      - jenkins-pass
+      - source: jenkins-pass
+        mode: 0400
       - cluster-info.properties
     deploy:
       placement:

--- a/jenkins/vfarcic-jenkins-master-agent-df-proxy-aws.yml
+++ b/jenkins/vfarcic-jenkins-master-agent-df-proxy-aws.yml
@@ -40,7 +40,8 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     secrets:
       - jenkins-user
-      - jenkins-pass
+      - source: jenkins-pass
+        mode: 0400
     deploy:
       placement:
         constraints: [node.role == manager]


### PR DESCRIPTION
This addresses part of [Password disclosure with Jenkins Swarm plugin](https://github.com/vfarcic/docker-flow-stacks/issues/15).  It moves the password into an environment variable and run the swarm plugin CLI as a non-root user (that has access to the Docker socket).

Workspace ownership and group will have to be modified to match the `jenkins` user in the swarm-agent container (numeric ID `1000`).